### PR TITLE
`power_size_results()` changes for `power_pool()` printing

### DIFF
--- a/R/power.R
+++ b/R/power.R
@@ -321,9 +321,39 @@ sample_size_pool <- function(pool_size, pool_number,
   total_clusters <- ceiling(total_clusters_raw)
   total_pools <- total_clusters * pool_number
   total_units <- total_pools * pool_size
+  if (sensitivity == 1 && specificity == 1) {
+    perf = "a perfect"
+  } else {
+    perf = "an imperfect"
+  }
+  text = paste0(
+    "A survey design using ", perf, 
+    " diagnostic test on pooled samples with the above parameters requires a total of ",
+    total_clusters, " clusters, ", 
+    total_pools, " total pools, and ", 
+    total_units, " total units."
+  )
   
-  return(list(clusters = total_clusters, pools = total_pools, units = total_units))
-  
+  power_size_results(  
+    sensitivity = sensitivity,
+    specificity = specificity,
+    # prevalence
+    prev_null = theta0,
+    prev_alt = thetaa,
+    correlation = correlation,
+    # statistical test
+    sig_level = sig_level,
+    power = power,
+    alternative = alternative,
+    # sample design
+    pool_size = pool_size,
+    pool_number = pool_number,
+    cluster_number = total_clusters,
+    total_pools = total_pools,
+    total_units = total_units,
+    # parsing
+    text = text
+  )
 }
 
 

--- a/R/power.R
+++ b/R/power.R
@@ -154,16 +154,34 @@ power_pool <- function(pool_size, pool_number, cluster_number,
                   stop('invalid alternative. options are less, greater, and two.sided')
   )
   
-  power_size_results(
-      pool_size = pool_size,
-      pool_number = pool_number,
-      cluster_number = cluster_number,
-      prev_null = theta0,
-      prev_alt = thetaa,
-      sig_level = sig_level,
-      power = power,
-      alternative = alternative,
-      target = "power"
+  total_pools = cluster_number * pool_number
+  total_units = total_pools * pool_size
+  if (sensitivity == 1 && specificity == 1) {
+    perf = "a perfect"
+  } else {
+    perf = "an imperfect"
+  }
+  text = paste("A survey design using", perf, "diagnostic test on pooled samples with the above parameters has a statistical power of", round(power, 3))
+  
+  power_size_results(  
+    sensitivity = sensitivity,
+    specificity = specificity,
+    # prevalence
+    prev_null = theta0,
+    prev_alt = thetaa,
+    correlation = correlation,
+    # statistical test
+    sig_level = sig_level,
+    power = power,
+    alternative = alternative,
+    # sample design
+    pool_size = pool_size,
+    pool_number = pool_number,
+    cluster_number = cluster_number,
+    total_pools = total_pools,
+    total_units = total_units,
+    # parsing
+    text = text
   )
   
 }

--- a/R/power.R
+++ b/R/power.R
@@ -154,6 +154,7 @@ power_pool <- function(pool_size, pool_number, cluster_number,
                   stop('invalid alternative. options are less, greater, and two.sided')
   )
   
+  # Prepare output
   total_pools = cluster_number * pool_number
   total_units = total_pools * pool_size
   if (sensitivity == 1 && specificity == 1) {
@@ -258,7 +259,33 @@ power_pool_random <- function(catch_dist, pool_strat, cluster_number,
                     stats::pnorm(((g(thetaa) - g(theta0))  - stats::qnorm(1-sig_level/2)/sqrt(fi0)) * sqrt(fia)),
                   stop('invalid alternative. options are less, greater, and two.sided')
   )
-  power
+  
+  # Prepare output
+  if (sensitivity == 1 && specificity == 1) {
+    perf = "a perfect"
+  } else {
+    perf = "an imperfect"
+  }
+  text = paste("A survey design using", perf, "diagnostic test on pooled samples with the above parameters has a statistical power of", round(power, 3))
+  
+  power_size_results(  
+    sensitivity = sensitivity,
+    specificity = specificity,
+    # prevalence
+    prev_null = theta0,
+    prev_alt = thetaa,
+    correlation = correlation,
+    # statistical test
+    sig_level = sig_level,
+    power = power,
+    alternative = alternative,
+    # sample design
+    catch_dist = catch_dist,
+    pool_strat = as.character(pool_strat),
+    cluster_number = cluster_number,
+    # parsing
+    text = text
+  )
 }
 
 #' @rdname power_pool

--- a/R/power_utils.R
+++ b/R/power_utils.R
@@ -13,25 +13,58 @@
 #'
 #' @examples
 #' # For power_pool()
-#' result <- power_size_results(pool_size = pool_size, pool_number = pool_number, cluster_number = cluster_number,
-#'                              prev_null = theta0, prev_alt = theta0, sig_level = sig_level,
-#'                              power = power, alternative = alternative, target = "power")
-#' print(result)
-
-power_size_results <- function(pool_size, pool_number, cluster_number,
-                               prev_null, prev_alt, sig_level, power,
-                               alternative, target) {
+#' result <- power_size_results(
+#'   sensitivity = 1, specificity = 1, prev_null = 0.01, prev_alt = 0.02,
+#'   correlation = 0, sig_level = 0.05, power = 0.76, # rounded in e.g. only
+#'   alternative = "greater", pool_size = 10, pool_number = 2, 
+#'   cluster_number = 50, total_pools = 100, total_units = 1000,
+#'   text = "... has a statistical power of 0.762"
+#' )
+#' 
+#' print(result) # pretty print
+#' result$stat_test$power
+power_size_results <- function(sensitivity, specificity, prev_null, prev_alt, 
+                               correlation, sig_level, power, alternative,
+                               pool_size, pool_number, cluster_number, 
+                               total_pools, total_units, text) {
+  
+  # Group parameters to different lists for printing
+  diag_test <- list(
+    title = "DIAGNOSTIC TEST",
+    sensitivity = sensitivity,
+    specificity = specificity
+  )
+  
+  prev <- list(
+    title = "PREVALENCE",
+    prev_null = prev_null,
+    prev_alt = prev_alt,
+    correlation = correlation
+  )
+  
+  stat_test <- list(
+    title = "STATISTICAL TEST",
+    sig_level = sig_level,
+    power = power,
+    alternative = alternative
+  )
+  
+  sample_design <- list(
+    title = "SAMPLE DESIGN",
+    pool_size = pool_size,
+    pool_number = pool_number,
+    cluster_number = cluster_number,
+    total_pools = total_pools,
+    total_units = total_units
+  )
+  
   results <- structure(
     list(
-      pool_size = pool_size,
-      pool_number = pool_number,
-      cluster_number = cluster_number,
-      prev_null = prev_null,
-      prev_alt = prev_alt,
-      sig_level = sig_level,
-      power = power,
-      alternative = alternative,
-      target = target
+      diag_test = diag_test,
+      prev = prev,
+      stat_test = stat_test,
+      sample_design = sample_design,
+      text = text 
     ),
     class = "power_size_results"
   )
@@ -40,19 +73,25 @@ power_size_results <- function(pool_size, pool_number, cluster_number,
 
 #' @method print power_size_results
 #' @export
-print.power_size_results <- function(x,...) {
-  # Remove 'target' from instance to decorate line of the
-  # inferred variable(s)
-  target_idx <- which(names(x) == "target")
-  target <- x[[target_idx]]
-  x <- x[-target_idx]
-
-  # decorate target line
-  name_idx <- which(names(x) == target)
-  names(x)[name_idx] <- paste("-->", names(x)[name_idx]) 
-   
-  # adapted from `stats::power.prop.test`
-  cat(paste(format(names(x), width = 15L, justify = "right"),
-            format(x), sep = " = "), sep = "\n")
+print.power_size_results <- function(x, ...) {
+  # Remove 'text' from instance for printing
+  text_idx <- which(names(x) == "text")
+  text <- x[[text_idx]]
+  x <- x[-text_idx]
+  
+  for (list in x) {
+    cat(paste("\n", list$title, "\n"))
+    for (name in names(list[-1])) { # skip title
+      if (name == "power") {
+        value <- round(list[[name]], 3)
+      } else {
+        value = list[[name]]
+      }
+      cat(paste(format(name, width = 15L, justify = "right"), value, sep = " = "
+), sep = "\n"
+      )
+    } 
+  }
+  cat("\n", text)
   invisible(x)
 }

--- a/R/power_utils.R
+++ b/R/power_utils.R
@@ -4,8 +4,21 @@
 #' and `sample_size_pool`), this class and print method ensures that outputs are
 #' stored and displayed consistently, summarising calculations results and the
 #' inputs for context.
-#'
-#' @param ... Input and inferred variables from relevant functions.
+#' 
+#' @param sensitivity .
+#' @param specificity .
+#' @param prev_null .
+#' @param prev_alt .
+#' @param correlation .
+#' @param sig_level .
+#' @param power .
+#' @param alternative .
+#' @param pool_size .
+#' @param pool_number .
+#' @param cluster_number . 
+#' @param total_pools .
+#' @param total_units .
+#' @param text chr Explanatory summary text to be printed at the end
 #'
 #' @return An object of class \code{power_size_results} containing selected
 #'   input parameters and results.

--- a/R/power_utils.R
+++ b/R/power_utils.R
@@ -13,8 +13,10 @@
 #' @param sig_level .
 #' @param power .
 #' @param alternative .
-#' @param pool_size .
-#' @param pool_number .
+#' @param pool_size required for power_pool and sample_size_pool
+#' @param pool_number required for power_pool and sample_size_pool
+#' @param catch_dist required for power_pool_random and sample_size_pool_random
+#' @param pool_strat required for power_pool_random and sample_size_pool_random
 #' @param cluster_number . 
 #' @param total_pools .
 #' @param total_units .
@@ -38,8 +40,9 @@
 #' result$stat_test$power
 power_size_results <- function(sensitivity, specificity, prev_null, prev_alt, 
                                correlation, sig_level, power, alternative,
-                               pool_size, pool_number, cluster_number, 
-                               total_pools, total_units, text) {
+                               pool_size = NA, pool_number = NA, catch_dist = NA, 
+                               pool_strat = NA, cluster_number, total_pools, 
+                               total_units, text) {
   
   # Group parameters to different lists for printing
   diag_test <- list(
@@ -62,13 +65,25 @@ power_size_results <- function(sensitivity, specificity, prev_null, prev_alt,
     alternative = alternative
   )
   
-  sample_design <- list(
-    title = "SAMPLE DESIGN",
-    pool_size = pool_size,
-    pool_number = pool_number,
-    cluster_number = cluster_number,
-    total_pools = total_pools,
-    total_units = total_units
+  if (!is.na(pool_size) && !is.na(pool_number)) {
+    temp_design <- list(
+      pool_size = pool_size,
+      pool_number = pool_number,
+      total_pools = total_pools,
+      total_units = total_units
+    )
+  } else { # *_random
+   temp_design <- list(
+      catch_mean = mean(catch_dist),
+      catch_variance = distributions3::variance(catch_dist),
+      pool_strat = pool_strat
+    )
+  }
+  
+  sample_design <- c(
+    list(title = "SAMPLE DESIGN"),
+    temp_design,
+    list(cluster_number = cluster_number)
   )
   
   results <- structure(

--- a/man/power_size_results.Rd
+++ b/man/power_size_results.Rd
@@ -13,8 +13,10 @@ power_size_results(
   sig_level,
   power,
   alternative,
-  pool_size,
-  pool_number,
+  pool_size = NA,
+  pool_number = NA,
+  catch_dist = NA,
+  pool_strat = NA,
   cluster_number,
   total_pools,
   total_units,
@@ -38,9 +40,13 @@ power_size_results(
 
 \item{alternative}{.}
 
-\item{pool_size}{.}
+\item{pool_size}{required for power_pool and sample_size_pool}
 
-\item{pool_number}{.}
+\item{pool_number}{required for power_pool and sample_size_pool}
+
+\item{catch_dist}{required for power_pool_random and sample_size_pool_random}
+
+\item{pool_strat}{required for power_pool_random and sample_size_pool_random}
 
 \item{cluster_number}{.}
 

--- a/man/power_size_results.Rd
+++ b/man/power_size_results.Rd
@@ -2,22 +2,53 @@
 % Please edit documentation in R/power_utils.R
 \name{power_size_results}
 \alias{power_size_results}
-\title{S3 Class and Methods for Power and Sample Size Calculation Outputs}
+\title{S3 class for power and sample size calculation outputs with pooled tests}
 \usage{
 power_size_results(
-  pool_size,
-  pool_number,
-  cluster_number,
+  sensitivity,
+  specificity,
   prev_null,
   prev_alt,
+  correlation,
   sig_level,
   power,
   alternative,
-  target
+  pool_size,
+  pool_number,
+  cluster_number,
+  total_pools,
+  total_units,
+  text
 )
 }
 \arguments{
-\item{...}{Input and inferred variables from relevant functions.}
+\item{sensitivity}{.}
+
+\item{specificity}{.}
+
+\item{prev_null}{.}
+
+\item{prev_alt}{.}
+
+\item{correlation}{.}
+
+\item{sig_level}{.}
+
+\item{power}{.}
+
+\item{alternative}{.}
+
+\item{pool_size}{.}
+
+\item{pool_number}{.}
+
+\item{cluster_number}{.}
+
+\item{total_pools}{.}
+
+\item{total_units}{.}
+
+\item{text}{chr Explanatory summary text to be printed at the end}
 }
 \value{
 An object of class \code{power_size_results} containing selected
@@ -31,8 +62,14 @@ inputs for context.
 }
 \examples{
 # For power_pool()
-result <- power_size_results(pool_size = pool_size, pool_number = pool_number, cluster_number = cluster_number,
-                             prev_null = theta0, prev_alt = theta0, sig_level = sig_level,
-                             power = power, alternative = alternative, target = "power")
-print(result)
+result <- power_size_results(
+  sensitivity = 1, specificity = 1, prev_null = 0.01, prev_alt = 0.02,
+  correlation = 0, sig_level = 0.05, power = 0.76, # rounded in e.g. only
+  alternative = "greater", pool_size = 10, pool_number = 2, 
+  cluster_number = 50, total_pools = 100, total_units = 1000,
+  text = "... has a statistical power of 0.762"
+)
+
+print(result) # pretty print
+result$stat_test$power
 }

--- a/tests/testthat/test-power.R
+++ b/tests/testthat/test-power.R
@@ -45,20 +45,20 @@ test_that(
 test_that(
   "power_pool_random()", {
     act <- power_pool_random(nb_catch(20,25), pool_target_number(2), cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01)
-    expect_equal(act, 0.613303, tolerance = 1e-6)
+    expect_equal(act$stat_test$power, 0.613303, tolerance = 1e-6)
   }
 )
 
 test_that(
   "power_pool_random() with links", {
     act <- power_pool_random(nb_catch(20,25), pool_target_number(2), cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01, link = "cloglog")
-    expect_equal(act, 0.6117088, tolerance = 1e-6)
+    expect_equal(act$stat_test$power, 0.6117088, tolerance = 1e-6)
     
     act <- power_pool_random(nb_catch(20,25), pool_target_number(2), cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01, link = "log")
-    expect_equal(act, 0.6100939, tolerance = 1e-6)
+    expect_equal(act$stat_test$power, 0.6100939, tolerance = 1e-6)
     
     act <- power_pool_random(nb_catch(20,25), pool_target_number(2), cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01, link = "identity")
-    expect_equal(act, 0.7568458, tolerance = 1e-6)
+    expect_equal(act$stat_test$power, 0.7568458, tolerance = 1e-6)
   }
 )
 

--- a/tests/testthat/test-power.R
+++ b/tests/testthat/test-power.R
@@ -1,24 +1,44 @@
 test_that(
-  "power_pool()", {
-  act <- power_pool(pool_size = 10, pool_number = 2, cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02)
-  expect_equal(act$power, 0.7617911, tolerance = 1e-6) 
-  
-  # With correlation
-  act <- power_pool(pool_size = 10, pool_number = 2, cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01)
-  expect_equal(act$power, 0.6213165, tolerance = 1e-6)
+  "power_pool() no corr", {
+    act <- power_pool(pool_size = 10, pool_number = 2, cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02)
+    expect_equal(act$stat_test$power, 0.7617911, tolerance = 1e-6) 
+    # tests for totals as they aren't direct inputs
+    expect_equal(act$sample_design$total_pools, 100) 
+    expect_equal(act$sample_design$total_units, 1000) 
+    expect_equal(act$text, "A survey design using a perfect diagnostic test on pooled samples with the above parameters has a statistical power of 0.762") 
+  }
+)
+
+test_that(
+  "power_pool() with corr", {
+    act <- power_pool(pool_size = 10, pool_number = 2, cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01)
+    expect_equal(act$stat_test$power, 0.6213165, tolerance = 1e-6)
+    expect_equal(act$sample_design$total_pools, 100) 
+    expect_equal(act$sample_design$total_units, 1000) 
+    expect_equal(act$text, "A survey design using a perfect diagnostic test on pooled samples with the above parameters has a statistical power of 0.621") 
+  }
+)
+
+test_that(
+  "power_pool() imperfect", {
+    act <- power_pool(pool_size = 15, pool_number = 3, cluster_number = 20, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01, sensitivity = 0.99, specificity = 0.98)
+    expect_equal(act$stat_test$power, 0.4350865, tolerance = 1e-6)
+    expect_equal(act$sample_design$total_pools, 60) 
+    expect_equal(act$sample_design$total_units, 900) 
+    expect_equal(act$text, "A survey design using an imperfect diagnostic test on pooled samples with the above parameters has a statistical power of 0.435") 
   }
 )
 
 test_that(
   "power_pool() links", {
   act <- power_pool(pool_size = 10, pool_number = 2, cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, link = "identity")
-  expect_equal(act$power, 0.8448746, tolerance = 1e-6) 
+  expect_equal(act$stat_test$power, 0.8448746, tolerance = 1e-6) 
   
   act <- power_pool(pool_size = 10, pool_number = 2, cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, link = "log")
-  expect_equal(act$power, 0.7598709, tolerance = 1e-6) 
+  expect_equal(act$stat_test$power, 0.7598709, tolerance = 1e-6) 
   
   act <- power_pool(pool_size = 10, pool_number = 2, cluster_number = 50, prevalence_null = 0.01, prevalence_alt = 0.02, link = "cloglog")
-  expect_equal(act$power, 0.7608382, tolerance = 1e-6) 
+  expect_equal(act$stat_test$power, 0.7608382, tolerance = 1e-6) 
   }
 )
 

--- a/tests/testthat/test-power.R
+++ b/tests/testthat/test-power.R
@@ -65,13 +65,40 @@ test_that(
 test_that(
   "sample_size_pool()", {
     act <- sample_size_pool(pool_size = 10, pool_number = 2, prevalence_null = 0.01, prevalence_alt = 0.02)
-    exp <- list(clusters = 55, pools = 110, units = 1100)
-    expect_equal(act, exp)
+    expect_equal(act$sample_design$cluster_number, 55)
+    expect_equal(act$sample_design$total_pools, 110)
+    expect_equal(act$sample_design$total_units, 1100)
+    expect_equal(
+      act$text, 
+      "A survey design using a perfect diagnostic test on pooled samples with the above parameters requires a total of 55 clusters, 110 total pools, and 1100 total units."
+    )
+  }
+)
     
+test_that(
+  "sample_size_pool with corr", {
     # Correlation
     act <- sample_size_pool(pool_size = 10, pool_number = 2, prevalence_null = 0.01, prevalence_alt = 0.02, correlation = 0.01)
-    exp <- list(clusters = 74, pools = 148, units = 1480)
-    expect_equal(act, exp)
+    expect_equal(act$sample_design$cluster_number, 74)
+    expect_equal(act$sample_design$total_pools, 148)
+    expect_equal(act$sample_design$total_units, 1480)
+    expect_equal(
+      act$text,
+      "A survey design using a perfect diagnostic test on pooled samples with the above parameters requires a total of 74 clusters, 148 total pools, and 1480 total units."
+    )
+  }
+)
+
+test_that(
+  "sample_size_pool imperfect test", {
+    act <- sample_size_pool(pool_size = 10, pool_number = 2, prevalence_null = 0.01, prevalence_alt = 0.02, sensitivity = 0.98, specificity = 0.99)
+    expect_equal(act$sample_design$cluster_number, 61)
+    expect_equal(act$sample_design$total_pools, 122)
+    expect_equal(act$sample_design$total_units, 1220)
+    expect_equal(
+      act$text, 
+      "A survey design using an imperfect diagnostic test on pooled samples with the above parameters requires a total of 61 clusters, 122 total pools, and 1220 total units."
+    )
   }
 )
 
@@ -79,14 +106,21 @@ test_that(
   "sample_size_pool() links", {
     act <- sample_size_pool(pool_size = 10, pool_number = 2, prevalence_null = 0.01, prevalence_alt = 0.02, link = "identity")
     exp <- list(clusters = 43, pools = 86, units = 860)
-    expect_equal(act, exp)
+    expect_equal(act$sample_design$cluster_number, 43)
+    expect_equal(act$sample_design$total_pools, 86)
+    expect_equal(act$sample_design$total_units, 860)
     
     act <- sample_size_pool(pool_size = 10, pool_number = 2, prevalence_null = 0.01, prevalence_alt = 0.02, link = "log")
     exp <- list(clusters = 55, pools = 110, units = 1100) # same as link = "logit"
-    expect_equal(act, exp)
+    expect_equal(act$sample_design$cluster_number, 55)
+    expect_equal(act$sample_design$total_pools, 110)
+    expect_equal(act$sample_design$total_units, 1100)
     
     act <- sample_size_pool(pool_size = 10, pool_number = 2, prevalence_null = 0.01, prevalence_alt = 0.02, link = "cloglog")
-    expect_equal(act, exp) # same as link = "logit"
+    # same as link = "logit"
+    expect_equal(act$sample_design$cluster_number, 55)
+    expect_equal(act$sample_design$total_pools, 110)
+    expect_equal(act$sample_design$total_units, 1100)
   }
 )
 

--- a/tests/testthat/test-power_utils.R
+++ b/tests/testthat/test-power_utils.R
@@ -1,0 +1,23 @@
+test_that(
+  "power_size_results constructor", {
+  # e.g. from power_pool() example
+  act <- power_size_results(
+    sensitivity = 1, 
+    specificity = 1, 
+    prev_null = 0.01,
+    prev_alt = 0.02,
+    correlation = 0,
+    sig_level = 0.05, 
+    power = 0.76, 
+    alternative = "greater",
+    pool_size = 10, 
+    pool_number = 2, 
+    cluster_number = 50,
+    total_pools = 100,
+    total_units = 1000,
+    text = "A survey design using a perfect diagnostic test on pooled samples with the above parameters has a statistical power of 0.762"
+  )
+  expect_s3_class(act, "power_size_results")
+  expect_equal(length(act), 5)
+  }
+)

--- a/tests/testthat/test-power_utils.R
+++ b/tests/testthat/test-power_utils.R
@@ -1,23 +1,47 @@
 test_that(
   "power_size_results constructor", {
-  # e.g. from power_pool() example
-  act <- power_size_results(
-    sensitivity = 1, 
-    specificity = 1, 
-    prev_null = 0.01,
-    prev_alt = 0.02,
-    correlation = 0,
-    sig_level = 0.05, 
-    power = 0.76, 
-    alternative = "greater",
-    pool_size = 10, 
-    pool_number = 2, 
-    cluster_number = 50,
-    total_pools = 100,
-    total_units = 1000,
-    text = "A survey design using a perfect diagnostic test on pooled samples with the above parameters has a statistical power of 0.762"
-  )
-  expect_s3_class(act, "power_size_results")
-  expect_equal(length(act), 5)
+    # e.g. from power_pool() example
+    act <- power_size_results(
+      sensitivity = 1, 
+      specificity = 1, 
+      prev_null = 0.01,
+      prev_alt = 0.02,
+      correlation = 0,
+      sig_level = 0.05, 
+      power = 0.76, 
+      alternative = "greater",
+      pool_size = 10, 
+      pool_number = 2, 
+      cluster_number = 50,
+      total_pools = 100,
+      total_units = 1000,
+      text = "A survey design using a perfect diagnostic test on pooled samples with the above parameters has a statistical power of 0.762"
+    )
+    expect_s3_class(act, "power_size_results")
+    expect_equal(length(act), 5)
+    expect_equal(length(act$sample_design), 6) # differs between _random or not
+  }
+)
+
+test_that(
+  "power_size_results constructor for _random", {
+    # e.g. from power_pool_random() example
+    act <- power_size_results(
+      sensitivity = 1, 
+      specificity = 1, 
+      prev_null = 0.01,
+      prev_alt = 0.02,
+      correlation = 0,
+      sig_level = 0.05, 
+      power = 0.62, 
+      alternative = "greater",
+      catch_dist = nb_catch(20, 25),
+      pool_strat = pool_target_number(2),
+      cluster_number = 50,
+      text = "A survey design using a perfect diagnostic test on pooled samples with the above parameters has a statistical power of 0.62"
+    )
+    expect_s3_class(act, "power_size_results")
+    expect_equal(length(act), 5)
+    expect_equal(length(act$sample_design), 5)
   }
 )


### PR DESCRIPTION
@AngusMcLure following on from #36 in a PR so it's easier to provide in-line comments before incorporating into the feature branch.

Changes:
- Add more attributes to `power_size_result` class
- Group related attributes in lists (e.g. access to `results$power` now `results$stat_test$power`)
- Update print method to output a summary line at the end, instead of marking the inferred param
- Update roxygen docs to fix undocumented params, left descriptions as `.`

Additions:
- test for constructing `power_size_result` 